### PR TITLE
Fix/config consistency check

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'TAO System Status',
     'description' => 'TAO System Status',
     'license' => 'GPL-2.0',
-    'version' => '0.11.2',
+    'version' => '0.11.3',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.13.3',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -71,7 +71,7 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('0.11.1');
         }
 
-        $this->skip('0.11.1', '0.11.2');
+        $this->skip('0.11.1', '0.11.3');
     }
 }
 


### PR DESCRIPTION
S3 bucket may not have `migratoins/config` folder (on non-taocloud instances). In that case `ConfigCongruenceS3Check` must be skipped.