### PR TITLE
Fix/is worker check

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'TAO System Status',
     'description' => 'TAO System Status',
     'license' => 'GPL-2.0',
-    'version' => '0.12.0',
+    'version' => '0.12.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.13.3',

--- a/model/Check/AbstractCheck.php
+++ b/model/Check/AbstractCheck.php
@@ -144,15 +144,11 @@ abstract class AbstractCheck implements CheckInterface
      */
     protected function isWorker(): bool
     {
-        if (DEBUG_MODE) {
-            return true;
-        }
-        exec('ps -ef |egrep \'.+www-data.*index.php\soat\'', $output);
+        exec('ps -ef |egrep \'.+index.php\soat\'', $output);
         $taskQueueProcesses = preg_grep('/RunWorker/', $output);
 
         return !empty($taskQueueProcesses);
     }
-
 
     /**
      * @return bool


### PR DESCRIPTION
On some workers php processes, such as RunWorker run not by 'www-data' group, but by 'apache' etc.
User group must not be taken into account.