### PR TITLE
add system status rest controller

### DIFF
--- a/controller/RestSystemStatus.php
+++ b/controller/RestSystemStatus.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
  *
  */
 

--- a/controller/RestSystemStatus.php
+++ b/controller/RestSystemStatus.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+namespace oat\taoSystemStatus\controller;
+
+use common_report_Report as Report;
+use oat\taoSystemStatus\model\SystemStatus\SystemStatusService;
+use oat\tao\model\http\HttpJsonResponseTrait;
+
+/**
+ * @OA\Info(title="Tao System Status API", version="0.1")
+ */
+
+/**
+ * @OA\Get(
+ *     path="/taoSystemStatus/api/systemStatus",
+ *     summary="Get system status data",
+ *     @OA\Response(
+ *         response="200",
+ *         description="Result of system check"
+ *     )
+ * )
+ */
+class RestSystemStatus extends \tao_actions_RestController
+{
+    use HttpJsonResponseTrait;
+
+    /**
+     * @return mixed
+     */
+    public function get()
+    {
+        /** @var Report[] $reports */
+        $reports = $this->getSystemStatusService()->check();
+        $this->setSuccessJsonResponse(['report' => $reports]);
+    }
+
+    /**
+     * @return SystemStatusService
+     */
+    protected function getSystemStatusService() : SystemStatusService
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(SystemStatusService::SERVICE_ID);
+    }
+}

--- a/doc/swagger.json
+++ b/doc/swagger.json
@@ -1,0 +1,19 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Tao System Status API",
+        "version": "0.1"
+    },
+    "paths": {
+        "/taoSystemStatus/api/systemStatus": {
+            "get": {
+                "summary": "Get system status data",
+                "responses": {
+                    "200": {
+                        "description": "Result of sustem check"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -19,16 +19,18 @@
  *
  */
 
+use oat\taoSystemStatus\model\Routing\ApiRoute;
 
 return [
     'name' => 'taoSystemStatus',
     'label' => 'TAO System Status',
     'description' => 'TAO System Status',
     'license' => 'GPL-2.0',
-    'version' => '0.12.1',
+    'version' => '0.13.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.13.3',
+        'taoScheduler' => '>=2.3.0',
     ],
     'acl' => [
         ['grant', 'http://www.tao.lu/Ontologies/generis.rdf#taoSystemStatusManager', ['ext' => 'taoSystemStatus']]
@@ -46,7 +48,8 @@ return [
     'uninstall' => [],
     'update' => oat\taoSystemStatus\scripts\update\Updater::class,
     'routes' => array(
-        '/taoSystemStatus' => 'oat\\taoSystemStatus\\controller'
+        '/taoSystemStatus/api' => ['class' => ApiRoute::class],
+        '/taoSystemStatus' => 'oat\\taoSystemStatus\\controller',
     ),
     'constants' => [
         'DIR_VIEWS' => __DIR__ . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR,

--- a/model/Routing/ApiRoute.php
+++ b/model/Routing/ApiRoute.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
  */
 
 namespace oat\taoSystemStatus\model\Routing;

--- a/model/Routing/ApiRoute.php
+++ b/model/Routing/ApiRoute.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoSystemStatus\model\Routing;
+
+use oat\tao\model\routing\AbstractApiRoute;
+
+class ApiRoute extends AbstractApiRoute
+{
+    const REST_CONTROLLER_PREFIX = 'oat\\taoSystemStatus\\controller\\Rest';
+
+    /**
+     * @inheritdoc
+     */
+    public static function getControllerPrefix()
+    {
+        return self::REST_CONTROLLER_PREFIX;
+    }
+}


### PR DESCRIPTION
Create system status Rest controller to be able to call API get report in json fromat.

To test it mage a `GET` call to the following endpoint: `http://your_tao_domain/taoSystemStatus/api/systemStatus`

Make sure that you set Accept:application/json header and that your user has `System Status Manager` role