### PR TITLE
Lead 86/system status alerts

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return [
     'label' => 'TAO System Status',
     'description' => 'TAO System Status',
     'license' => 'GPL-2.0',
-    'version' => '0.13.0',
+    'version' => '0.14.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.13.3',

--- a/model/Report/ReportComparator.php
+++ b/model/Report/ReportComparator.php
@@ -135,9 +135,6 @@ class ReportComparator
     {
         $result = [];
         foreach ($report->getChildren() as $childReport) {
-            if ($childReport->getType() === Report::TYPE_INFO) {
-                continue;
-            }
             $result[$childReport->getData()[CheckInterface::PARAM_CHECK_ID]] = $childReport;
         }
         ksort($result);

--- a/model/Report/ReportComparator.php
+++ b/model/Report/ReportComparator.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/model/Report/ReportComparator.php
+++ b/model/Report/ReportComparator.php
@@ -135,7 +135,10 @@ class ReportComparator
     {
         $result = [];
         foreach ($report->getChildren() as $childReport) {
-            $result[$childReport->getData()[CheckInterface::PARAM_CHECK_ID]] = $childReport;
+            $reportData = $childReport->getData();
+            if (isset($reportData[CheckInterface::PARAM_CHECK_ID])) {
+                $result[$reportData[CheckInterface::PARAM_CHECK_ID]] = $childReport;
+            }
         }
         ksort($result);
         return $result;

--- a/model/Report/ReportComparator.php
+++ b/model/Report/ReportComparator.php
@@ -117,7 +117,7 @@ class ReportComparator
      * @param Report $newReports
      * @return int
      */
-    private function getTrend(Report $oldReport, Report $newReports)
+    private function getTrend(Report $oldReport, Report $newReports): int
     {
         return self::REPORTS_MAP[$oldReport->getType()] - self::REPORTS_MAP[$newReports->getType()];
     }

--- a/model/Report/ReportComparator.php
+++ b/model/Report/ReportComparator.php
@@ -44,10 +44,11 @@ class ReportComparator
      */
     private $newReport;
 
-    const REPORTS_MAP = [
+    const REPORT_WEIGHT_MAP = [
         Report::TYPE_SUCCESS => 0,
-        Report::TYPE_WARNING => 1,
-        Report::TYPE_ERROR => 2,
+        Report::TYPE_INFO => 1,
+        Report::TYPE_WARNING => 2,
+        Report::TYPE_ERROR => 3,
     ];
 
     /**
@@ -92,12 +93,12 @@ class ReportComparator
         return $report;
     }
 
-    private function compare(callable $trendComparator): Result
+    private function compare(callable $trendComparator): Report
     {
         $oldReports = $this->mapReportsById($this->oldReport);
         $newReports = $this->mapReportsById($this->newReport);
 
-        $result = new Report(Report::TYPE_SUCCESS, 'No changes found');
+        $result = Report::createInfo();
 
         foreach ($oldReports as $reportId => $oldReport) {
             if (!isset($newReports[$reportId])) {
@@ -107,6 +108,10 @@ class ReportComparator
             if ($trendComparator($trend)) {
                 $result->add($newReports[$reportId]);
             }
+        }
+
+        if (!$result->hasChildren()) {
+            $result->setMessage('No changes found');
         }
 
         return $result;
@@ -119,7 +124,7 @@ class ReportComparator
      */
     private function getTrend(Report $oldReport, Report $newReports): int
     {
-        return self::REPORTS_MAP[$oldReport->getType()] - self::REPORTS_MAP[$newReports->getType()];
+        return self::REPORT_WEIGHT_MAP[$oldReport->getType()] - self::REPORT_WEIGHT_MAP[$newReports->getType()];
     }
 
     /**

--- a/model/Report/ReportComparator.php
+++ b/model/Report/ReportComparator.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoSystemStatus\model\Report;
+
+use common_report_Report as Report;
+use oat\taoSystemStatus\model\Check\CheckInterface;
+
+/**
+ * Class ReportComparator
+ *
+ * Comparator is used to get difference between 2 reports and find degradations or restorations of system status
+ *
+ * @package oat\taoSystemStatus\model\Report
+ */
+class ReportComparator
+{
+    /**
+     * @var Report
+     */
+    private $oldReport;
+
+    /**
+     * @var Report
+     */
+    private $newReport;
+
+    const REPORTS_MAP = [
+        Report::TYPE_SUCCESS => 0,
+        Report::TYPE_WARNING => 1,
+        Report::TYPE_ERROR => 2,
+    ];
+
+    /**
+     * ReportComparator constructor.
+     * @param Report $oldReport
+     * @param Report $newReport
+     */
+    public function __construct(Report $oldReport, Report $newReport)
+    {
+        $this->oldReport = $oldReport;
+        $this->newReport = $newReport;
+    }
+
+    /**
+     * @return Report
+     */
+    public function getDegradations(): Report
+    {
+        return $this->compare(function ($trend) {
+            return $trend < 0;
+        });
+    }
+
+    public function getRestorations(): Report
+    {
+        return $this->compare(function ($trend) {
+            return $trend > 0;
+        });
+    }
+
+    private function compare($trendComparator)
+    {
+        $oldReports = $this->mapReportsById($this->oldReport);
+        $newReports = $this->mapReportsById($this->newReport);
+
+        $result = new Report(Report::TYPE_INFO);
+
+        foreach ($oldReports as $reportId => $oldReport) {
+            if (!isset($newReports[$reportId])) {
+                continue;
+            }
+            $trend = $this->getTrend($oldReport, $newReports[$reportId]);
+            if ($trendComparator($trend)) {
+                $result->add($newReports[$reportId]);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param Report $oldReport
+     * @param Report $newReports
+     * @return int
+     */
+    private function getTrend(Report $oldReport, Report $newReports)
+    {
+        return self::REPORTS_MAP[$oldReport->getType()] - self::REPORTS_MAP[$newReports->getType()];
+    }
+
+    /**
+     * @param Report $report
+     * @return Report[]
+     */
+    private function mapReportsById(Report $report): array
+    {
+        $result = [];
+        foreach ($report->getChildren() as $childReport) {
+            $result[$childReport->getData()[CheckInterface::PARAM_CHECK_ID]] = $childReport;
+        }
+        ksort($result);
+        return $result;
+    }
+}

--- a/model/Report/ReportComparator.php
+++ b/model/Report/ReportComparator.php
@@ -92,7 +92,7 @@ class ReportComparator
         return $report;
     }
 
-    private function compare($trendComparator)
+    private function compare(callable $trendComparator): Result
     {
         $oldReports = $this->mapReportsById($this->oldReport);
         $newReports = $this->mapReportsById($this->newReport);

--- a/scripts/tools/CheckDegradations.php
+++ b/scripts/tools/CheckDegradations.php
@@ -72,11 +72,11 @@ class CheckDegradations extends ScriptAction
         $report = $this->getSystemStatusService()->check();
         $previousReport = $this->getPreviousReport();
         if (!$previousReport) {
-            return new Report(Report::TYPE_INFO, 'No previous report found');
+            $result = new Report(Report::TYPE_INFO, 'No previous report found');
+        } else {
+            $comparator = new ReportComparator($previousReport, $report);
+            $result = $comparator->getDegradations();
         }
-
-        $comparator = new ReportComparator($previousReport, $report);
-        $result = $comparator->getDegradations();
 
         $this->getPersistence()->set(self::KV_PERSISTENCE_KEY, json_encode($report));
         return $result;

--- a/scripts/tools/CheckDegradations.php
+++ b/scripts/tools/CheckDegradations.php
@@ -52,7 +52,7 @@ class CheckDegradations extends ScriptAction
                 'prefix' => 'p',
                 'longPrefix' => 'persistence',
                 'required' => true,
-                'description' => 'The KeyValue persistence where you want store results of previous check',
+                'description' => 'The KeyValue persistence identifier (see your persistence config) where you want store results of previous check',
             ],
         ];
     }

--- a/scripts/tools/CheckDegradations.php
+++ b/scripts/tools/CheckDegradations.php
@@ -94,8 +94,10 @@ class CheckDegradations extends ScriptAction
 
     /**
      * @return Report|null
+     * @throws \common_exception_Error
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
      */
-    private function getPreviousReport()
+    private function getPreviousReport():?Report
     {
         $report = $this->getPersistence()->get(self::KV_PERSISTENCE_KEY);
         $result = null;

--- a/scripts/tools/CheckDegradations.php
+++ b/scripts/tools/CheckDegradations.php
@@ -70,7 +70,7 @@ class CheckDegradations extends ScriptAction
         $report = $this->getSystemStatusService()->check();
         $previousReport = $this->getPreviousReport();
         if (!$previousReport) {
-            return new Report('No previous report found');
+            return new Report(Report::TYPE_INFO, 'No previous report found');
         }
 
         $comparator = new ReportComparator($previousReport, $report);

--- a/scripts/tools/CheckDegradations.php
+++ b/scripts/tools/CheckDegradations.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/scripts/tools/CheckDegradations.php
+++ b/scripts/tools/CheckDegradations.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoSystemStatus\scripts\tools;
+
+use oat\generis\persistence\PersistenceManager;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\taoSystemStatus\model\Report\ReportComparator;
+use oat\taoSystemStatus\model\SystemStatus\SystemStatusService;
+use common_report_Report as Report;
+
+/**
+ * Class CheckDegradations
+ *
+ * ```bash
+ * $ sudo -u www-data php index.php '\oat\taoSystemStatus\scripts\tools\CheckDegradations' -p default_kv
+ * ```
+ *
+ * @package oat\taoSystemStatus\scripts\tools
+ * @author Aleh Hutnikau, <hutnikau@1pt.com>
+ */
+class CheckDegradations extends ScriptAction
+{
+    private const KV_PERSISTENCE_KEY = self::class.'::systems_status_report';
+
+    /**
+     * @return array[]
+     */
+    public function provideOptions()
+    {
+        return [
+            'persistence' => [
+                'prefix' => 'p',
+                'longPrefix' => 'persistence',
+                'required' => true,
+                'description' => 'The KeyValue persistence where you want store results of previous check',
+            ],
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function provideDescription()
+    {
+        return 'Script checks if there are any degradations in the system status since last launch';
+    }
+
+    public function run()
+    {
+        $report = $this->getSystemStatusService()->check();
+        $previousReport = $this->getPreviousReport();
+        if (!$previousReport) {
+            return new Report('No previous report found');
+        }
+
+        $comparator = new ReportComparator($previousReport, $report);
+        $result = $comparator->getDegradations();
+
+        $this->getPersistence()->set(self::KV_PERSISTENCE_KEY, json_encode($report));
+        return $result;
+    }
+
+    /**
+     * @return Report|null
+     */
+    private function getPreviousReport()
+    {
+        $report = $this->getPersistence()->get(self::KV_PERSISTENCE_KEY);
+        $result = null;
+        if ($report) {
+            $report = json_decode($report, true);
+            $result = Report::jsonUnserialize($report);
+        }
+        return $result;
+    }
+
+    /**
+     * @return \common_persistence_KeyValuePersistence
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     */
+    private function getPersistence()
+    {
+        $id = $this->getOption('persistence');
+        return $this->getServiceManager()
+            ->get(PersistenceManager::SERVICE_ID)
+            ->getPersistenceById($id);
+    }
+
+    /**
+     * @return SystemStatusService
+     */
+    protected function getSystemStatusService() : SystemStatusService
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(SystemStatusService::SERVICE_ID);
+    }
+}

--- a/scripts/tools/CheckDegradations.php
+++ b/scripts/tools/CheckDegradations.php
@@ -81,6 +81,18 @@ class CheckDegradations extends ScriptAction
     }
 
     /**
+     * @return array|string[]
+     */
+    protected function provideUsage()
+    {
+        return [
+            'prefix' => 'h',
+            'longPrefix' => 'help',
+            'description' => 'Prints a help statement'
+        ];
+    }
+
+    /**
      * @return Report|null
      */
     private function getPreviousReport()

--- a/scripts/tools/CheckDegradations.php
+++ b/scripts/tools/CheckDegradations.php
@@ -25,6 +25,7 @@ namespace oat\taoSystemStatus\scripts\tools;
 use oat\generis\persistence\PersistenceManager;
 use oat\oatbox\extension\script\ScriptAction;
 use oat\taoSystemStatus\model\Report\ReportComparator;
+use oat\taoSystemStatus\model\SystemStatus\InstanceStatusService;
 use oat\taoSystemStatus\model\SystemStatus\SystemStatusService;
 use common_report_Report as Report;
 
@@ -67,6 +68,7 @@ class CheckDegradations extends ScriptAction
 
     public function run()
     {
+        $this->getInstanceStatusService()->check();
         $report = $this->getSystemStatusService()->check();
         $previousReport = $this->getPreviousReport();
         if (!$previousReport) {
@@ -127,5 +129,13 @@ class CheckDegradations extends ScriptAction
     {
         /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $this->getServiceLocator()->get(SystemStatusService::SERVICE_ID);
+    }
+
+    /**
+     * @return InstanceStatusService
+     */
+    private function getInstanceStatusService() : InstanceStatusService
+    {
+        return $this->getServiceLocator()->get(InstanceStatusService::SERVICE_ID);
     }
 }

--- a/test/model/CheckStorage/RdsCheckStorageTest.php
+++ b/test/model/CheckStorage/RdsCheckStorageTest.php
@@ -44,11 +44,9 @@ class RdsCheckStorageTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $checks[0]->getParameters());
     }
 
-    /**
-     * @expectedException  \oat\taoSystemStatus\model\SystemStatusException
-     */
     public function testAddCheckException()
     {
+        $this->expectException('\oat\taoSystemStatus\model\SystemStatusException');
         $service = $this->getInstance();
         $service->addCheck($this->getCheckMock(CheckInterface::TYPE_INSTANCE, ['foo' => 'bar']));
         $service->addCheck($this->getCheckMock(CheckInterface::TYPE_INSTANCE, ['foo' => 'bar']));

--- a/test/model/CheckStorage/RdsCheckStorageTest.php
+++ b/test/model/CheckStorage/RdsCheckStorageTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/test/model/Report/ReportComparatorTest.php
+++ b/test/model/Report/ReportComparatorTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/test/model/Report/ReportComparatorTest.php
+++ b/test/model/Report/ReportComparatorTest.php
@@ -38,7 +38,7 @@ class ReportComparatorTest extends TestCase
         $oldReport = $this->getInitialReport();
         $newReport = $this->getNewReport();
 
-        $expected = new Report(Report::TYPE_INFO);
+        $expected = new Report(Report::TYPE_WARNING, 'Service degradations found');
         $expected->add($this->getReport(Report::TYPE_WARNING, 'Check A warning', 'A'));
         $expected->add($this->getReport(Report::TYPE_ERROR, 'Check E error', 'E'));
         $expected->add($this->getReport(Report::TYPE_ERROR, 'Check G error', 'G'));
@@ -48,7 +48,7 @@ class ReportComparatorTest extends TestCase
 
         //No degradations - empty report
         $comparator = new ReportComparator($oldReport, $oldReport);
-        $this->assertEquals(new Report(Report::TYPE_INFO), $comparator->getDegradations());
+        $this->assertFalse($comparator->getDegradations()->hasChildren());
     }
 
     public function testGetRestorations()
@@ -56,7 +56,7 @@ class ReportComparatorTest extends TestCase
         $oldReport = $this->getInitialReport();
         $newReport = $this->getNewReport();
 
-        $expected = new Report(Report::TYPE_INFO);
+        $expected = new Report(Report::TYPE_SUCCESS, 'Service restorations found');
         $expected->add($this->getReport(Report::TYPE_SUCCESS, 'Check B success', 'B'));
         $expected->add($this->getReport(Report::TYPE_WARNING, 'Check C warning', 'C'));
         $expected->add($this->getReport(Report::TYPE_SUCCESS, 'Check F success', 'F'));

--- a/test/model/Report/ReportComparatorTest.php
+++ b/test/model/Report/ReportComparatorTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoSystemStatus\test\model\Report;
+
+use common_report_Report as Report;
+use oat\generis\test\TestCase;
+use oat\taoSystemStatus\model\Check\CheckInterface;
+use oat\taoSystemStatus\model\Report\ReportComparator;
+
+/**
+ * Class ReportComparatorTest
+ * @package oat\taoSystemStatus\test\model\SystemStatus
+ * @author Aleh Hutnikau, <hutnikau@1pt.com>
+ */
+class ReportComparatorTest extends TestCase
+{
+
+    public function testGetDegradations()
+    {
+        $oldReport = $this->getInitialReport();
+        $newReport = $this->getNewReport();
+
+        $expected = new Report(Report::TYPE_INFO);
+        $expected->add($this->getReport(Report::TYPE_WARNING, 'Check A warning', 'A'));
+        $expected->add($this->getReport(Report::TYPE_ERROR, 'Check E error', 'E'));
+        $expected->add($this->getReport(Report::TYPE_ERROR, 'Check G error', 'G'));
+
+        $comparator = new ReportComparator($oldReport, $newReport);
+        $this->assertEquals($expected, $comparator->getDegradations());
+
+        //No degradations - empty report
+        $comparator = new ReportComparator($oldReport, $oldReport);
+        $this->assertEquals(new Report(Report::TYPE_INFO), $comparator->getDegradations());
+    }
+
+    public function testGetRestorations()
+    {
+        $oldReport = $this->getInitialReport();
+        $newReport = $this->getNewReport();
+
+        $expected = new Report(Report::TYPE_INFO);
+        $expected->add($this->getReport(Report::TYPE_SUCCESS, 'Check B success', 'B'));
+        $expected->add($this->getReport(Report::TYPE_WARNING, 'Check C warning', 'C'));
+        $expected->add($this->getReport(Report::TYPE_SUCCESS, 'Check F success', 'F'));
+
+        $comparator = new ReportComparator($oldReport, $newReport);
+        $this->assertEquals($expected, $comparator->getRestorations());
+    }
+
+    private function getInitialReport()
+    {
+        $oldReport = new Report(Report::TYPE_INFO);
+        $oldReport->add($this->getReport(Report::TYPE_SUCCESS, 'Check A success', 'A'));
+        $oldReport->add($this->getReport(Report::TYPE_WARNING, 'Check B warning', 'B'));
+        $oldReport->add($this->getReport(Report::TYPE_ERROR, 'Check C error', 'C'));
+        $oldReport->add($this->getReport(Report::TYPE_SUCCESS, 'Check D success', 'D'));
+        $oldReport->add($this->getReport(Report::TYPE_WARNING, 'Check E warning', 'E'));
+        $oldReport->add($this->getReport(Report::TYPE_ERROR, 'Check F error', 'F'));
+        $oldReport->add($this->getReport(Report::TYPE_SUCCESS, 'Check G success', 'G'));
+
+        return $oldReport;
+    }
+
+    private function getNewReport()
+    {
+        $newReport = new Report(Report::TYPE_INFO);
+        $newReport->add($this->getReport(Report::TYPE_WARNING, 'Check A warning', 'A'));//success -> warning -1
+        $newReport->add($this->getReport(Report::TYPE_SUCCESS, 'Check B success', 'B'));//warning -> success +1
+        $newReport->add($this->getReport(Report::TYPE_WARNING, 'Check C warning', 'C'));//error   -> warning +1
+        $newReport->add($this->getReport(Report::TYPE_SUCCESS, 'Check D success', 'D'));//success -> success  0
+        $newReport->add($this->getReport(Report::TYPE_ERROR, 'Check E error', 'E'));    //warning -> error   -1
+        $newReport->add($this->getReport(Report::TYPE_SUCCESS, 'Check F success', 'F'));//error   -> success +2
+        $newReport->add($this->getReport(Report::TYPE_ERROR, 'Check G error', 'G'));    //success   -> error -2
+        return $newReport;
+    }
+
+    private function getReport($type, $message, $id = null): Report
+    {
+        return new Report($type, $message, [
+            CheckInterface::PARAM_CHECK_ID => $id,
+            CheckInterface::PARAM_DETAILS => $id,
+        ]);
+    }
+}

--- a/test/model/SystemStatus/SystemStatusServiceTest.php
+++ b/test/model/SystemStatus/SystemStatusServiceTest.php
@@ -33,14 +33,6 @@ class SystemStatusServiceTest extends TestCase
 {
     const SERVICE_ID = 'taoSystemStatus/SystemCheckService';
 
-    /**
-     * @inheritdoc
-     */
-    public function testCheck()
-    {
-
-    }
-
     public function testGetInstanceId()
     {
         $instanceId = $this->getInstance()->getInstanceId();

--- a/test/model/SystemStatus/SystemStatusServiceTest.php
+++ b/test/model/SystemStatus/SystemStatusServiceTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Added the script which check if there is any system status degradation since last check.

To test it do the following steps:
1. Make sure that mathJax installed. 
1.a) "Install" if it's required with the following command: `mkdir -p taoQtiItem/views/js/mathjax/ && touch taoQtiItem/views/js/mathjax/MathJax.js`
2. Run degradations checker: `php index.php '\oat\taoSystemStatus\scripts\tools\CheckDegradations' -p default_kv` (no degradations should be found)
3. Delete or rename mathjax file (`taoQtiItem/views/js/mathjax/MathJax.js`)
4. Run degradations checker: `php index.php '\oat\taoSystemStatus\scripts\tools\CheckDegradations' -p default_kv` (Service degradations found ...)