### PR TITLE
Feature/check s3 cache directory

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return [
     'label' => 'TAO System Status',
     'description' => 'TAO System Status',
     'license' => 'GPL-2.0',
-    'version' => '0.13.0',
+    'version' => '0.14.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=38.13.3',

--- a/migrations/Version202010150815402719_taoSystemStatus.php
+++ b/migrations/Version202010150815402719_taoSystemStatus.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoSystemStatus\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoSystemStatus\model\Check\System\FileSystemS3CachePathCheck;
+use oat\taoSystemStatus\model\SystemStatus\SystemStatusService;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202010150815402719_taoSystemStatus extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Register FileSystemS3CachePathCheck';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $check = new FileSystemS3CachePathCheck([]);
+        /** @var SystemStatusService $systemStatusService */
+        $systemStatusService = $this->getServiceLocator()->get(SystemStatusService::SERVICE_ID);
+        $systemStatusService->addCheck($check);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $check = new FileSystemS3CachePathCheck([]);
+        /** @var SystemStatusService $systemStatusService */
+        $systemStatusService = $this->getServiceLocator()->get(SystemStatusService::SERVICE_ID);
+        $systemStatusService->removeCheck($check);
+    }
+}

--- a/model/Check/System/FileSystemS3CacheCheck.php
+++ b/model/Check/System/FileSystemS3CacheCheck.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/model/Check/System/FileSystemS3CacheCheck.php
+++ b/model/Check/System/FileSystemS3CacheCheck.php
@@ -122,12 +122,7 @@ class FileSystemS3CacheCheck extends AbstractCheck
         /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $this->getServiceLocator()->get(FileSystemService::SERVICE_ID);
     }
-
-    /**
-     * Get configuration of filesystem adapter
-     * @param $id
-     * @return mixed
-     */
+    
     private function getFlysystemAdapterConfig(string $id): array
     {
         $fsService = $this->getFileSystemService();

--- a/model/Check/System/FileSystemS3CacheCheck.php
+++ b/model/Check/System/FileSystemS3CacheCheck.php
@@ -128,7 +128,7 @@ class FileSystemS3CacheCheck extends AbstractCheck
      * @param $id
      * @return mixed
      */
-    private function getFlysystemAdapterConfig($id): array
+    private function getFlysystemAdapterConfig(string $id): array
     {
         $fsService = $this->getFileSystemService();
         $dirs = $fsService->hasOption(FileSystemService::OPTION_DIRECTORIES)

--- a/model/Check/System/FileSystemS3CacheCheck.php
+++ b/model/Check/System/FileSystemS3CacheCheck.php
@@ -122,7 +122,7 @@ class FileSystemS3CacheCheck extends AbstractCheck
         /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $this->getServiceLocator()->get(FileSystemService::SERVICE_ID);
     }
-    
+
     private function getFlysystemAdapterConfig(string $id): array
     {
         $fsService = $this->getFileSystemService();

--- a/model/Check/System/FileSystemS3CachePathCheck.php
+++ b/model/Check/System/FileSystemS3CachePathCheck.php
@@ -42,10 +42,9 @@ class FileSystemS3CachePathCheck extends AbstractCheck
 {
 
     /**
-     * @param array $params
-     * @return Report
+     * @inheritdoc
      */
-    public function __invoke(array $params = []): Report
+    public function __invoke($params = []): Report
     {
         if (!$this->isActive()) {
             return new Report(Report::TYPE_INFO, 'Check ' . $this->getId() . ' is not active');

--- a/model/Check/System/FileSystemS3CachePathCheck.php
+++ b/model/Check/System/FileSystemS3CachePathCheck.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -14,7 +17,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 

--- a/model/Check/System/FileSystemS3CachePathCheck.php
+++ b/model/Check/System/FileSystemS3CachePathCheck.php
@@ -45,7 +45,7 @@ class FileSystemS3CachePathCheck extends AbstractCheck
      * @param array $params
      * @return Report
      */
-    public function __invoke($params = []): Report
+    public function __invoke(array $params = []): Report
     {
         if (!$this->isActive()) {
             return new Report(Report::TYPE_INFO, 'Check ' . $this->getId() . ' is not active');

--- a/model/Check/System/FileSystemS3CachePathCheck.php
+++ b/model/Check/System/FileSystemS3CachePathCheck.php
@@ -25,20 +25,18 @@ use oat\oatbox\filesystem\FileSystemService;
 use oat\taoSystemStatus\model\Check\AbstractCheck;
 
 /**
- * Class FileSystemS3CacheCheck
+ * Class FileSystemS3CachePathCheck
+ *
+ * It is possible to upload a PHP file using the MediaManager extension.
+ * It is important to note that this is the expected behavior of the application as all kind of files can be uploaded.
+ *
+ * Those files must be outside of directory available from web
+ *
  * @package oat\taoSystemStatus\model\Check\System
- * @author Aleksej Tikhanovich, <aleksej@taotesting.com>
+ * @author Aleh Hutnikau, <aleh@taotesting.com>
  */
-class FileSystemS3CacheCheck extends AbstractCheck
+class FileSystemS3CachePathCheck extends AbstractCheck
 {
-
-    const CACHED_FILESYSTEMS = [
-        'public',
-        'private',
-        'qtiItemPci',
-        'qtiItemImsPci',
-        'portableElementStorage'
-    ];
 
     /**
      * @param array $params
@@ -49,7 +47,7 @@ class FileSystemS3CacheCheck extends AbstractCheck
         if (!$this->isActive()) {
             return new Report(Report::TYPE_INFO, 'Check ' . $this->getId() . ' is not active');
         }
-        $report = $this->checkFileSystemConfig();
+        $report = $this->checkFilesystemCaches();
         return $this->prepareReport($report);
     }
 
@@ -84,31 +82,39 @@ class FileSystemS3CacheCheck extends AbstractCheck
      */
     public function getDetails(): string
     {
-        return __('Cache status on S3 file system adapters');
+        return __('Cache directory path on S3 file system adapters');
     }
 
     /**
      * @return Report
      */
-    private function checkFileSystemConfig() : Report
+    private function checkFilesystemCaches() : Report
     {
-        $adaptersWithoutCache = [];
-        foreach (self::CACHED_FILESYSTEMS as $fsId) {
-            $adapter = $this->getFlysystemAdapterConfig($fsId);
-            $options = array_pop($adapter['options']);
+        $adaptersWithCacheInsideTaoRoot = [];
+        $taoRootDir = $this->getTaoRootDir();
+        $adapters = $this->getFileSystemService()->getOption(FileSystemService::OPTION_ADAPTERS);
+        foreach ($adapters as $adapterId => $adapterConfig) {
+            if (!isset($adapterConfig['options'])) {
+                continue;
+            }
+            $options = array_pop($adapterConfig['options']);
             if (!isset($options['cache'])) {
-                $adaptersWithoutCache[] = $fsId;
+                continue;
+            }
+            $cachePath = realpath($options['cache']);
+            if (strpos($cachePath, $taoRootDir) === 0) {
+                $adaptersWithCacheInsideTaoRoot[] = $adapterId;
             }
         }
 
-        if (!empty($adaptersWithoutCache)) {
+        if (!empty($adaptersWithCacheInsideTaoRoot)) {
             return new Report(
                 Report::TYPE_WARNING,
-                __('Cache is disabled for File System adapters: %s', implode(', ', $adaptersWithoutCache))
+                __('Cache directory is inside tao root directory. Filesystem adapters: %s', implode(', ', $adaptersWithCacheInsideTaoRoot))
             );
         }
 
-        return new Report(Report::TYPE_SUCCESS, __('Filesystem adapters correctly configured.'));
+        return new Report(Report::TYPE_SUCCESS, __('Cache directories of filesystem adapters correctly configured.'));
     }
 
     /**
@@ -121,31 +127,10 @@ class FileSystemS3CacheCheck extends AbstractCheck
     }
 
     /**
-     * Get configuration of filesystem adapter
-     * @param $id
-     * @return mixed
+     * @return string
      */
-    private function getFlysystemAdapterConfig($id): array
+    private function getTaoRootDir(): string
     {
-        $fsService = $this->getFileSystemService();
-        $dirs = $fsService->hasOption(FileSystemService::OPTION_DIRECTORIES)
-            ? $fsService->getOption(FileSystemService::OPTION_DIRECTORIES)
-            : [];
-
-        if (!isset($dirs[$id])) {
-            $adapterId = $id;
-        } elseif (is_array($dirs[$id])) {
-            $adapterId = $dirs[$id]['adapter'];
-        } else {
-            $adapterId = $dirs[$id];
-        }
-
-        $fsConfig = $fsService->getOption(FileSystemService::OPTION_ADAPTERS);
-        $adapterConfig = $fsConfig[$adapterId];
-        // alias?
-        while (is_string($adapterConfig)) {
-            $adapterConfig = $fsConfig[$adapterConfig];
-        }
-        return $adapterConfig;
+        return realpath(rtrim(ROOT_PATH, '\\/').DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR);
     }
 }

--- a/scripts/install/RegisterChecks.php
+++ b/scripts/install/RegisterChecks.php
@@ -87,6 +87,7 @@ class RegisterChecks extends AbstractAction
             new \oat\taoSystemStatus\model\Check\Instance\CronCheck([]),
             new \oat\taoSystemStatus\model\Check\System\TaskQueueMonitoring([]),
             new \oat\taoSystemStatus\model\Check\System\WebSourceTTLCheck([]),
+            new \oat\taoSystemStatus\model\Check\System\FileSystemS3CachePathCheck([]),
         ];
     }
 


### PR DESCRIPTION
for more details see: https://oat-sa.atlassian.net/browse/SI-478

Steps to test:
1. set implementation of `config/generis/filesystem.conf.php` to `oat\awsTools\AwsFileSystemService`
2. add s3 filesystem adapter (make sure that cache folder is inside of tao root):
```
's3' => array(
            'class' => 'oat\\awsTools\\AwsFlyWrapper',
            'options' => array(
                array(
                    'bucket' => 'xxx-xxx-xxx-xxx-xxx',
                    'client' => 'generis/awsClient',
                    'prefix' => 'data/qtiItemPci',
                    'cache' => '/Users/aleh/domains/package-tao/tao'
                )
            )
        ),
```
3. Open system status page.