### PR TITLE
Fix/file system s3 cache path check cache path retrieval

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return [
     'label' => 'TAO System Status',
     'description' => 'TAO System Status',
     'license' => 'GPL-2.0',
-    'version' => '0.17.0',
+    'version' => '0.17.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=46.11.1',

--- a/model/Check/System/FileSystemS3CachePathCheck.php
+++ b/model/Check/System/FileSystemS3CachePathCheck.php
@@ -100,7 +100,7 @@ class FileSystemS3CachePathCheck extends AbstractCheck
                 continue;
             }
             $options = array_pop($adapterConfig['options']);
-            if (!isset($options['cache'])) {
+            if (!isset($options['cache']) || !is_string($options['cache'])) {
                 continue;
             }
             $cachePath = realpath($options['cache']);


### PR DESCRIPTION
Fix cache path retrieval.

cache parameter of S3 file system may be set to `false` what causes the following error:
```
php error(1) in /var/www/html/tao/taoSystemStatus/model/Check/System/FileSystemS3CachePathCheck.php@107: Uncaught TypeError: strpos() expects parameter 1 to be string, boolean given 
```