### PR TITLE
Fix/check wkhtmltopdf only on worker

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return [
     'label' => 'TAO System Status',
     'description' => 'TAO System Status',
     'license' => 'GPL-2.0',
-    'version' => '0.19.1',
+    'version' => '0.19.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'tao' => '>=46.11.1',

--- a/model/Check/Instance/WkhtmltopdfCheck.php
+++ b/model/Check/Instance/WkhtmltopdfCheck.php
@@ -78,7 +78,7 @@ class WkhtmltopdfCheck extends AbstractCheck
      */
     public function isActive(): bool
     {
-        return $this->ifTaoBookletIsInstalled();
+        return $this->ifTaoBookletIsInstalled() && $this->isWorker();
     }
 
     /**


### PR DESCRIPTION
wkhtmltopdf needs to be installed only on worker instance.
Webserver should treat this check as not active.