### PR TITLE
fix: validate filesystem cache path

### DIFF
--- a/model/Check/System/AwsRedisFreeSpaceCheck.php
+++ b/model/Check/System/AwsRedisFreeSpaceCheck.php
@@ -67,7 +67,7 @@ class AwsRedisFreeSpaceCheck extends AbstractCheck
 
         $freeSpacePercentage = $this->getFreePercentage($clusterData['CacheClusterId']);
 
-        if ($freeSpacePercentage < 30) {
+        if ($freeSpacePercentage < 40) {
             $report = new Report(Report::TYPE_ERROR, round($freeSpacePercentage) . '%');
         } elseif ($freeSpacePercentage < 50) {
             $report = new Report(Report::TYPE_WARNING, round($freeSpacePercentage) . '%');


### PR DESCRIPTION
if directory configured in path does not exist or user has no rights then it should raise a warning