### PR TITLE
Fix/wkhtmltopdf binary path check

### DIFF
--- a/model/Check/Instance/WkhtmltopdfCheck.php
+++ b/model/Check/Instance/WkhtmltopdfCheck.php
@@ -60,7 +60,7 @@ class WkhtmltopdfCheck extends AbstractCheck
         }
 
         $bin = $options['binary'];
-        if ($guessPath !== $bin) {
+        if (realpath(trim($guessPath)) !== realpath(trim($bin))) {
             return new Report(
                 Report::TYPE_WARNING,
                 __('wkhtmltopdf lib not correctly configured in taoBooklet extension. Please, check config/taoBooklet/wkhtmltopdf.conf.php.')


### PR DESCRIPTION
`$guessPath` ends with a line break.
That leads to failing the check with the message `wkhtmltopdf lib not correctly configured in taoBooklet extension.`