### PR TITLE
Fix: clean up temporary local FS directory after repetitive  S3 check

### DIFF
--- a/model/Check/Instance/ConfigCongruenceS3Check.php
+++ b/model/Check/Instance/ConfigCongruenceS3Check.php
@@ -39,7 +39,8 @@ class ConfigCongruenceS3Check extends AbstractCheck
      */
     protected function doCheck(): Report
     {
-        $tmpDir = \tao_helpers_File::createTempDir() . 'migrations' . DIRECTORY_SEPARATOR . 'config';
+        $tmpRootDir = \tao_helpers_File::createTempDir();
+        $tmpDir = $tmpRootDir . 'migrations' . DIRECTORY_SEPARATOR . 'config';
         $s3Client = $this->getS3Client();
         $adapterOptions = $this->getAdapterOptions();
         $bucket = $adapterOptions['options'][0]['bucket'];
@@ -51,6 +52,9 @@ class ConfigCongruenceS3Check extends AbstractCheck
             $this->logError('The instance configuration is not match configuration stored on s3');
             $report = new Report(Report::TYPE_ERROR, __('The instance configuration is not match configuration stored on s3'));
         }
+
+        \tao_helpers_File::delTree($tmpRootDir);
+
         return $report;
     }
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/NSA-177

Bug:
the configs fetched from s3 to tmp folder to check against application configs are not removed. Which pollutes tmp folder increasing its size (each downloaded copy has a size of 17Mb) and "eating" hardlink limit on it

Fixed:
the temporary directory is deleted once the S3 check is done