### PR TITLE
PHP 8 migration

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,27 @@
+name: Continuous integration
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php-version: [ '7.4', '8.0', '8.1' ]
+        include:
+          - php-version: '8.1'
+            coverage: true
+
+    steps:
+      - name: CI
+        uses: oat-sa/tao-extension-ci-action@v1
+        with:
+          php: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -25,3 +25,4 @@ jobs:
         with:
           php: ${{ matrix.php-version }}
           coverage: ${{ matrix.coverage }}
+          test-suites-path: test/model

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
             "role": "Developer"
         }
     ],
-    "homepage" : "http://www.taotesting.com",
-    "license" : "GPL-2.0-only",
+    "homepage": "http://www.taotesting.com",
+    "license": "GPL-2.0-only",
     "keywords": [
         "tao",
         "computer-based-assessment",
@@ -26,11 +26,11 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php" : ">=7.1",
+        "php": ">=7.1",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis" : ">=14.0.0",
-        "oat-sa/tao-core" : ">=50.2.0",
-        "oat-sa/extension-tao-scheduler" : ">=3.0.0"
+        "oat-sa/generis": ">=15.22",
+        "oat-sa/tao-core": ">=50.24.6",
+        "oat-sa/extension-tao-scheduler": ">=3.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.1",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.22",
         "oat-sa/tao-core": ">=50.24.6",


### PR DESCRIPTION
[ADF-1097](https://oat-sa.atlassian.net/browse/ADF-1097)
[ADF-1087](https://oat-sa.atlassian.net/browse/ADF-1087)
[ADF-1105](https://oat-sa.atlassian.net/browse/ADF-1105)

## Goal
Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.