### PR TITLE
Fix/oatsd 2213/fix taskqueue memory issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": ">=50.24.6",
+        "oat-sa/tao-core": ">=50.30.0",
         "oat-sa/extension-tao-scheduler": ">=3.0.0"
     },
     "autoload": {

--- a/model/Check/System/TaskQueueFinishedCheck.php
+++ b/model/Check/System/TaskQueueFinishedCheck.php
@@ -21,13 +21,17 @@
 namespace oat\taoSystemStatus\model\Check\System;
 
 use common_report_Report as Report;
-use oat\tao\model\taskQueue\TaskLog\Broker\TaskLogBrokerInterface;
-use oat\tao\model\taskQueue\TaskLog\TaskLogFilter;
+use DateInterval;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 use oat\taoSystemStatus\model\Check\AbstractCheck;
 use oat\tao\model\taskQueue\TaskLogInterface;
 use oat\tao\helpers\Template;
 use common_Exception;
 use Exception;
+use Renderer;
+use tao_helpers_Date;
 
 /**
  * Class TaskQueueFinishedCheck
@@ -47,11 +51,11 @@ class TaskQueueFinishedCheck extends AbstractCheck
      */
     protected function doCheck(): Report
     {
-        $statistics = $this->getTasksStatistics();
-
-        $report = new Report(Report::TYPE_SUCCESS, __('Task Queue statistics:'));
-        $report->setData($statistics);
-        return $report;
+        return new Report(
+            Report::TYPE_SUCCESS,
+            __('Task Queue statistics:'),
+            $this->getTasksStatistics()
+        );
     }
 
     /**
@@ -94,7 +98,7 @@ class TaskQueueFinishedCheck extends AbstractCheck
     public function renderReport(Report $report): string
     {
         /** @var Report $taskReport */
-        $renderer = new \Renderer(Template::getTemplate('Reports/taskStatisticsReport.tpl', 'taoSystemStatus'));
+        $renderer = new Renderer(Template::getTemplate('Reports/taskStatisticsReport.tpl', 'taoSystemStatus'));
         $renderer->setData('task-report', $report);
         $renderer->setData('task-statistics', json_encode($report->getData()));
         return $renderer->render();
@@ -110,14 +114,14 @@ class TaskQueueFinishedCheck extends AbstractCheck
 
         $result = [];
         foreach (self::OPTIONS_INTERVAL as $name => $interval) {
-            $intervalObj = new \DateInterval($interval);
-            $period = new \DateInterval($name);
+            $intervalObj = new DateInterval($interval);
+            $period = new DateInterval($name);
 
             $points = round($this->getIntervalSeconds($period) / $this->getIntervalSeconds($intervalObj));
 
-            $timeKeys = \tao_helpers_Date::getTimeKeys(
-                new \DateInterval($interval),
-                new \DateTime('now', new \DateTimeZone('UTC')),
+            $timeKeys = tao_helpers_Date::getTimeKeys(
+                new DateInterval($interval),
+                new DateTime('now', new DateTimeZone('UTC')),
                 $points
             );
 
@@ -138,13 +142,13 @@ class TaskQueueFinishedCheck extends AbstractCheck
     }
 
     /**
-     * @param \DateInterval $interval
+     * @param DateInterval $interval
      * @return int
      * @throws Exception
      */
-    private function getIntervalSeconds(\DateInterval $interval)
+    private function getIntervalSeconds(DateInterval $interval)
     {
-        $reference = new \DateTimeImmutable;
+        $reference = new DateTimeImmutable;
         $endTime = $reference->add($interval);
 
         return $endTime->getTimestamp() - $reference->getTimestamp();

--- a/model/Check/System/TaskQueueFinishedCheck.php
+++ b/model/Check/System/TaskQueueFinishedCheck.php
@@ -25,6 +25,7 @@ use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
+use oat\oatbox\reporting\ReportInterface;
 use oat\taoSystemStatus\model\Check\AbstractCheck;
 use oat\tao\model\taskQueue\TaskLogInterface;
 use oat\tao\helpers\Template;
@@ -52,7 +53,7 @@ class TaskQueueFinishedCheck extends AbstractCheck
     protected function doCheck(): Report
     {
         return new Report(
-            Report::TYPE_SUCCESS,
+            ReportInterface::TYPE_SUCCESS,
             __('Task Queue statistics:'),
             $this->getTasksStatistics()
         );

--- a/model/Check/System/TaskQueueFinishedCheck.php
+++ b/model/Check/System/TaskQueueFinishedCheck.php
@@ -118,7 +118,14 @@ class TaskQueueFinishedCheck extends AbstractCheck
             $intervalObj = new DateInterval($interval);
             $period = new DateInterval($name);
 
-            $points = round($this->getIntervalSeconds($period) / $this->getIntervalSeconds($intervalObj));
+            $intervalSeconds =$this->getIntervalSeconds($intervalObj);
+            $periodSeconds =$this->getIntervalSeconds($period);
+
+            if ($intervalSeconds == 0 || $periodSeconds == 0) {
+                $points = null;
+            } else {
+                $points = round($this->getIntervalSeconds($period) / $this->getIntervalSeconds($intervalObj));
+            }
 
             $timeKeys = tao_helpers_Date::getTimeKeys(
                 new DateInterval($interval),

--- a/model/SystemStatus/SystemStatusService.php
+++ b/model/SystemStatus/SystemStatusService.php
@@ -22,7 +22,6 @@ namespace oat\taoSystemStatus\model\SystemStatus;
 
 use common_report_Report as Report;
 use oat\taoSystemStatus\model\Check\CheckInterface;
-use oat\taoSystemStatus\model\Check\System\TaskQueueFinishedCheck;
 use oat\taoSystemStatus\model\SystemStatusLog\SystemStatusLogService;
 use oat\taoSystemStatus\model\SystemStatusLog\SystemStatusLogStorageInterface;
 

--- a/model/SystemStatus/SystemStatusService.php
+++ b/model/SystemStatus/SystemStatusService.php
@@ -22,6 +22,7 @@ namespace oat\taoSystemStatus\model\SystemStatus;
 
 use common_report_Report as Report;
 use oat\taoSystemStatus\model\Check\CheckInterface;
+use oat\taoSystemStatus\model\Check\System\TaskQueueFinishedCheck;
 use oat\taoSystemStatus\model\SystemStatusLog\SystemStatusLogService;
 use oat\taoSystemStatus\model\SystemStatusLog\SystemStatusLogStorageInterface;
 

--- a/test/model/Check/System/TaskQueueFinishedCheckTest.php
+++ b/test/model/Check/System/TaskQueueFinishedCheckTest.php
@@ -62,6 +62,7 @@ class TaskQueueFinishedCheckTest extends TestCase
         $this->taskLogService->expects($this->any())
             ->method('getTaskExecutionTimesByDateRange')
             ->willReturn([]);
+
         $data = (($this->subject)())->getData();
 
         $this->assertCount(7, $data);

--- a/test/model/Check/System/TaskQueueFinishedCheckTest.php
+++ b/test/model/Check/System/TaskQueueFinishedCheckTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoSystemStatus\test\model\Check\System;
+
+use oat\generis\test\PersistenceManagerMockTrait;
+use oat\oatbox\service\ServiceManager;
+use oat\tao\model\taskQueue\TaskLogInterface;
+use oat\taoSystemStatus\model\Check\CheckInterface;
+use oat\taoSystemStatus\model\Check\System\TaskQueueFinishedCheck;
+use PHPUnit\Framework\TestCase;
+
+class TaskQueueFinishedCheckTest extends TestCase
+{
+    use PersistenceManagerMockTrait;
+
+    private TaskQueueFinishedCheck $subject;
+    private TaskLogInterface $taskLogService;
+
+    protected function setUp(): void
+    {
+        $this->subject = new TaskQueueFinishedCheck();
+
+        $serviceLocatorMock = $this->createMock(ServiceManager::class);
+        $this->taskLogService = $this->createMock(TaskLogInterface::class);
+
+        $serviceLocatorMock->expects($this->once())
+            ->method('has')
+            ->with(TaskLogInterface::SERVICE_ID)
+            ->willReturn(true);
+
+        $serviceLocatorMock->expects($this->once())
+            ->method('get')
+            ->with(TaskLogInterface::SERVICE_ID)
+            ->willReturn($this->taskLogService);
+
+        $this->subject->setServiceLocator($serviceLocatorMock);
+    }
+
+    public function testDoCheck(): void
+    {
+        $this->taskLogService->expects($this->any())
+            ->method('getTaskExecutionTimesByDateRange')
+            ->willReturn([]);
+        $data = (($this->subject)())->getData();
+
+        $this->assertCount(7, $data);
+
+        $this->assertArrayHasKey('P1D', $data);
+        $this->assertCount(3, $data['P1D']);
+
+        $this->assertArrayHasKey('time', $data['P1D']);
+        $this->assertArrayHasKey('average', $data['P1D']);
+        $this->assertArrayHasKey('amount', $data['P1D']);
+        $this->assertCount(144, $data['P1D']['time']);
+        $this->assertCount(144, $data['P1D']['average']);
+        $this->assertCount(144, $data['P1D']['amount']);
+
+        $this->assertArrayHasKey('P1W', $data);
+        $this->assertCount(3, $data['P1W']);
+
+        $this->assertArrayHasKey('time', $data['P1W']);
+        $this->assertArrayHasKey('average', $data['P1W']);
+        $this->assertArrayHasKey('amount', $data['P1W']);
+        $this->assertCount(168, $data['P1W']['time']);
+        $this->assertCount(168, $data['P1W']['average']);
+        $this->assertCount(168, $data['P1W']['amount']);
+
+        $this->assertArrayHasKey('P1M', $data);
+        $this->assertCount(3, $data['P1M']);
+
+        $this->assertArrayHasKey('time', $data['P1M']);
+        $this->assertArrayHasKey('average', $data['P1M']);
+        $this->assertArrayHasKey('amount', $data['P1M']);
+        $this->assertCount(186, $data['P1M']['time']);
+        $this->assertCount(186, $data['P1M']['average']);
+        $this->assertCount(186, $data['P1M']['amount']);
+
+        $this->assertArrayHasKey(CheckInterface::PARAM_CATEGORY, $data);
+        $this->assertEquals(__('Monitoring / Statistics'), $data[CheckInterface::PARAM_CATEGORY]);
+        $this->assertArrayHasKey(CheckInterface::PARAM_DETAILS, $data);
+        $this->assertEquals(__('Statistics of processed tasks'), $data[CheckInterface::PARAM_DETAILS]);
+        $this->assertArrayHasKey(CheckInterface::PARAM_CHECK_ID, $data);
+        $this->assertEquals(get_class($this->subject), $data[CheckInterface::PARAM_CHECK_ID]);
+        $this->assertArrayHasKey(CheckInterface::PARAM_DATE, $data);
+    }
+}

--- a/views/templates/Reports/taskReport.tpl
+++ b/views/templates/Reports/taskReport.tpl
@@ -9,7 +9,7 @@ $reports = get_data('reports');
     <thead>
         <tr>
             <th><?= __('Label') ?></th>
-            <th><?= __('Creted At') ?></th>
+            <th><?= __('Created At') ?></th>
             <th><?= __('Details') ?></th>
         </tr>
     </thead>


### PR DESCRIPTION
**Description**
With 800k tasks in `tq_task_log`,  taskqueue monitoring is causes memory error.
By removing php abstraction TaskLogEntity and by querying directly for timeout, php process is smoother

This PR is only about changing interfaces. To have all required pieces please test with https://github.com/oat-sa/tao-core/pull/3685

**Ticket**
https://oat-sa.atlassian.net/browse/OATSD-2213

**How to test**
Generate some tasks for last month. 
Launch taoSystemStatus page, taskqueue monitoring
=> Taskqueue graph is displayed as usual
To go deeper generate 100k tasks
