### PR TITLE
feat: added support to check aurora AcuUtilization instead rds free space

### DIFF
--- a/model/Check/System/AwsRDSAcuUtilizationCheck.php
+++ b/model/Check/System/AwsRDSAcuUtilizationCheck.php
@@ -114,7 +114,7 @@ class AwsRDSAcuUtilizationCheck extends AbstractAwsRDSCheck
      */
     public function getAcuUtilization(array $instanceData)
     {
-//        $params = $this->getParameters();
+        $params = $this->getParameters();
         $period = $params[self::PARAM_PERIOD] ?? self::PARAM_DEFAULT_PERIOD;
         $interval = new DateInterval('PT' . $period . 'S');
         $since = (new DateTime())->sub($interval);

--- a/model/Check/System/AwsRDSAcuUtilizationCheck.php
+++ b/model/Check/System/AwsRDSAcuUtilizationCheck.php
@@ -114,6 +114,7 @@ class AwsRDSAcuUtilizationCheck extends AbstractAwsRDSCheck
      */
     public function getAcuUtilization(array $instanceData)
     {
+        $params = $this->getParameters();
         $period = $params[self::PARAM_PERIOD] ?? self::PARAM_DEFAULT_PERIOD;
         $interval = new DateInterval('PT' . $period . 'S');
         $since = (new DateTime())->sub($interval);

--- a/model/Check/System/AwsRDSAcuUtilizationCheck.php
+++ b/model/Check/System/AwsRDSAcuUtilizationCheck.php
@@ -114,7 +114,7 @@ class AwsRDSAcuUtilizationCheck extends AbstractAwsRDSCheck
      */
     public function getAcuUtilization(array $instanceData)
     {
-        $params = $this->getParameters();
+//        $params = $this->getParameters();
         $period = $params[self::PARAM_PERIOD] ?? self::PARAM_DEFAULT_PERIOD;
         $interval = new DateInterval('PT' . $period . 'S');
         $since = (new DateTime())->sub($interval);

--- a/model/Check/System/AwsRDSFreeSpaceCheck.php
+++ b/model/Check/System/AwsRDSFreeSpaceCheck.php
@@ -193,7 +193,7 @@ class AwsRDSFreeSpaceCheck extends AbstractAwsRDSCheck
         }
 
         foreach ($dbClusterInstances['DBClusters'] as $dbInstance) {
-            if (str_starts_with($dbInstance['DBClusterIdentifier'], $stackId)) {
+            if (strpos($dbInstance['DBClusterIdentifier'], $stackId) === 0) {
                 return true;
             }
         }

--- a/model/Check/System/AwsRDSFreeSpaceCheck.php
+++ b/model/Check/System/AwsRDSFreeSpaceCheck.php
@@ -109,7 +109,7 @@ class AwsRDSFreeSpaceCheck extends AbstractAwsRDSCheck
      */
     public function getFreePercentage(array $instanceData)
     {
-        $params = $this->getParameters();
+//        $params = $this->getParameters();
         $period = $params[self::PARAM_PERIOD] ?? self::PARAM_DEFAULT_PERIOD;
         $interval = new DateInterval('PT' . $period . 'S');
         $since = (new DateTime())->sub($interval);

--- a/model/Check/System/AwsRDSFreeSpaceCheck.php
+++ b/model/Check/System/AwsRDSFreeSpaceCheck.php
@@ -109,7 +109,7 @@ class AwsRDSFreeSpaceCheck extends AbstractAwsRDSCheck
      */
     public function getFreePercentage(array $instanceData)
     {
-//        $params = $this->getParameters();
+        $params = $this->getParameters();
         $period = $params[self::PARAM_PERIOD] ?? self::PARAM_DEFAULT_PERIOD;
         $interval = new DateInterval('PT' . $period . 'S');
         $since = (new DateTime())->sub($interval);

--- a/model/Check/System/AwsRDSFreeSpaceCheck.php
+++ b/model/Check/System/AwsRDSFreeSpaceCheck.php
@@ -109,6 +109,7 @@ class AwsRDSFreeSpaceCheck extends AbstractAwsRDSCheck
      */
     public function getFreePercentage(array $instanceData)
     {
+        $params = $this->getParameters();
         $period = $params[self::PARAM_PERIOD] ?? self::PARAM_DEFAULT_PERIOD;
         $interval = new DateInterval('PT' . $period . 'S');
         $since = (new DateTime())->sub($interval);
@@ -166,15 +167,15 @@ class AwsRDSFreeSpaceCheck extends AbstractAwsRDSCheck
             return null;
         }
 
-        $InstanceData = null;
+        $instanceData = null;
         foreach ($dbInstances['DBInstances'] as $dbInstance) {
-            if (str_starts_with($dbInstance['DBInstanceIdentifier'], $stackId)) {
-                $InstanceData = $dbInstance;
+            if (strpos($dbInstance['DBInstanceIdentifier'], $stackId) === 0) {
+                $instanceData = $dbInstance;
                 break;
             }
         }
 
-        return $InstanceData;
+        return $instanceData;
     }
 
     /**

--- a/test/model/Check/System/TaskQueueFinishedCheckTest.php
+++ b/test/model/Check/System/TaskQueueFinishedCheckTest.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace oat\taoSystemStatus\test\model\Check\System;
 
+use DateTime;
+use DateTimeZone;
 use oat\generis\test\PersistenceManagerMockTrait;
 use oat\oatbox\service\ServiceManager;
 use oat\tao\model\taskQueue\TaskLogInterface;
@@ -91,9 +93,14 @@ class TaskQueueFinishedCheckTest extends TestCase
         $this->assertArrayHasKey('time', $data['P1M']);
         $this->assertArrayHasKey('average', $data['P1M']);
         $this->assertArrayHasKey('amount', $data['P1M']);
-        $this->assertCount(186, $data['P1M']['time']);
-        $this->assertCount(186, $data['P1M']['average']);
-        $this->assertCount(186, $data['P1M']['amount']);
+
+        $dateTime = new DateTime('now', new DateTimeZone('UTC'));
+        $daysInMonth = cal_days_in_month(CAL_GREGORIAN, (int)$dateTime->format('m'), (int)$dateTime->format('Y'));
+        $expectedPeriods = $daysInMonth * 24 / 4;
+
+        $this->assertCount($expectedPeriods, $data['P1M']['time']);
+        $this->assertCount($expectedPeriods, $data['P1M']['average']);
+        $this->assertCount($expectedPeriods, $data['P1M']['amount']);
 
         $this->assertArrayHasKey(CheckInterface::PARAM_CATEGORY, $data);
         $this->assertEquals(__('Monitoring / Statistics'), $data[CheckInterface::PARAM_CATEGORY]);


### PR DESCRIPTION
Ticket - https://oat-sa.atlassian.net/browse/REL-917

## Goal
Support has been added to monitoring the Aurora AcuUtilization system when the program works with it.

## Changelog
- feat: added support to check aurora AcuUtilization instead rds free space

## How to test
1. Open Tools -> System status page to see the system status monitor
2. There is 'Used space on RDS storage' for RDS instances and 'ACU Utilization on RDS storage' for Aurora cluster instances
3. You can check unit tests for Aurora system status checker `AwsRDSAcuUtilizationCheckTest`
